### PR TITLE
OraclePlatform - ORA-01427: single-row subquery returns more than one row

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/OraclePlatform.php
@@ -674,6 +674,7 @@ END;';
                              FROM   $colCommentsTableName d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
                              AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.OWNER = c.OWNER
                          ) AS comments
                 FROM     $tabColumnsTableName c
                 WHERE    c.table_name = " . $table . " $ownerCondition

--- a/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
+++ b/tests/Doctrine/Tests/DBAL/Platforms/OraclePlatformTest.php
@@ -727,6 +727,7 @@ EOD;
                              FROM   user_col_comments d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
                              AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.OWNER = c.OWNER
                          ) AS comments
                 FROM     user_tab_columns c
                 WHERE    c.table_name = 'test' 
@@ -740,6 +741,7 @@ EOD;
                              FROM   user_col_comments d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
                              AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.OWNER = c.OWNER
                          ) AS comments
                 FROM     user_tab_columns c
                 WHERE    c.table_name = 'test' 
@@ -753,6 +755,7 @@ EOD;
                              FROM   all_col_comments d
                              WHERE  d.TABLE_NAME = c.TABLE_NAME
                              AND    d.COLUMN_NAME = c.COLUMN_NAME
+                             AND    d.OWNER = c.OWNER
                          ) AS comments
                 FROM     all_tab_columns c
                 WHERE    c.table_name = 'test' AND c.owner = 'SCOTT'


### PR DESCRIPTION
The table "all_col_comments" contains all column comments for all database tables in all tablespaces. If the connection user has access to multiple tablespaces, this query fails with the following error:
ORA-01427: single-row subquery returns more than one row
